### PR TITLE
Update JoyGivers.xml

### DIFF
--- a/1.3/Defs/JoyGiverDefs/JoyGivers.xml
+++ b/1.3/Defs/JoyGiverDefs/JoyGivers.xml
@@ -15,5 +15,21 @@
       <li>Manipulation</li>
     </requiredCapacities>
   </JoyGiverDef>
-  
+	
+	<JoyGiverDef>
+		<defName>VCE_EatDessert</defName>
+		<giverClass>JoyGiver_Ingest</giverClass>
+		<baseChance>2.5</baseChance>
+		<thingDefs>
+			<li>VCE_SimpleDessert</li>
+			<li>VCE_FineDessert</li>
+			<li>VCE_LavishDessert</li>
+			<li>VCE_GourmetDessert</li>
+		</thingDefs>
+		<joyKind>VCE_Confectionery</joyKind>
+		<requiredCapacities>
+			<li>Manipulation</li>
+		</requiredCapacities>
+	</JoyGiverDef>
+
 </Defs>


### PR DESCRIPTION
Adds a JoyGiver for desserts, which previously would never be automatically eaten for recreation. 

[If this was intentionally omitted, please decline the PR.]